### PR TITLE
add find-similar 1.2.1 with python 3.11 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==4.2.4
-find-similar==1.2.0
+find-similar==1.2.1
 djangorestframework==3.14.0
 markdown2==2.4.10
 django-filter==23.2


### PR DESCRIPTION
`find-similar==1.2.1` has been added to `requirements.txt`